### PR TITLE
WIP fix: update to current base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-From ubuntu:trusty
+FROM debian:stable
 MAINTAINER Simon Templer <simon@templer.cc>
 
 # Set noninteractive mode for apt-get
@@ -9,7 +9,15 @@ RUN apt-get update
 
 # Start editing
 # Install package here for cache
-RUN apt-get -y install supervisor postfix sasl2-bin opendkim opendkim-tools
+#
+# XXX postfix installation fails due to automatically created myhostname setting
+RUN apt-get -y install postfix; \
+    postconf -e myhostname=localhost && \
+    apt-get -y install rsyslog supervisor sasl2-bin opendkim opendkim-tools
+
+# XXX again installing postfix is probably not required
+RUN postconf -h myhostname && \
+    apt-get -y install postfix
 
 # Add files
 ADD assets/install.sh /opt/install.sh


### PR DESCRIPTION
Image can be built but postfix fails to start.
Either analyse what the issue is or try to migrate to other existing more current Docker build.